### PR TITLE
Add UniPC variant option

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ For example, to install sage-attention (linux):
 
 However, you are highly recommended to first try without sage-attention since it will influence results, though the influence is minimal.
 
+The UniPC sampler provides two internal variants: `bh1` (default) and `bh2`. `bh2` can maintain motion details slightly better but may drift from the prompt. You can choose the variant in the dropdown of the Gradio scripts.
+
 # GUI
 
 ![ui](https://github.com/user-attachments/assets/8c5cdbb1-b80c-4b7e-ac27-83834ac24cc4)

--- a/demo_gradio.py
+++ b/demo_gradio.py
@@ -100,7 +100,7 @@ os.makedirs(outputs_folder, exist_ok=True)
 
 
 @torch.no_grad()
-def worker(input_image, prompt, n_prompt, seed, total_second_length, latent_window_size, steps, cfg, gs, rs, gpu_memory_preservation, use_teacache, mp4_crf):
+def worker(input_image, prompt, n_prompt, seed, total_second_length, latent_window_size, steps, cfg, gs, rs, gpu_memory_preservation, use_teacache, mp4_crf, variant):
     total_latent_sections = (total_second_length * 30) / (latent_window_size * 4)
     total_latent_sections = int(max(round(total_latent_sections), 1))
 
@@ -266,6 +266,7 @@ def worker(input_image, prompt, n_prompt, seed, total_second_length, latent_wind
                 clean_latent_2x_indices=clean_latent_2x_indices,
                 clean_latents_4x=clean_latents_4x,
                 clean_latent_4x_indices=clean_latent_4x_indices,
+                variant=variant,
                 callback=callback,
             )
 
@@ -315,7 +316,22 @@ def worker(input_image, prompt, n_prompt, seed, total_second_length, latent_wind
     return
 
 
-def process(input_image, prompt, n_prompt, seed, total_second_length, latent_window_size, steps, cfg, gs, rs, gpu_memory_preservation, use_teacache, mp4_crf):
+def process(
+    input_image,
+    prompt,
+    n_prompt,
+    seed,
+    total_second_length,
+    latent_window_size,
+    steps,
+    cfg,
+    gs,
+    rs,
+    gpu_memory_preservation,
+    use_teacache,
+    mp4_crf,
+    variant,
+):
     global stream
     assert input_image is not None, 'No input image!'
 
@@ -323,7 +339,23 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
 
     stream = AsyncStream()
 
-    async_run(worker, input_image, prompt, n_prompt, seed, total_second_length, latent_window_size, steps, cfg, gs, rs, gpu_memory_preservation, use_teacache, mp4_crf)
+    async_run(
+        worker,
+        input_image,
+        prompt,
+        n_prompt,
+        seed,
+        total_second_length,
+        latent_window_size,
+        steps,
+        cfg,
+        gs,
+        rs,
+        gpu_memory_preservation,
+        use_teacache,
+        mp4_crf,
+        variant,
+    )
 
     output_filename = None
 
@@ -387,6 +419,13 @@ with block:
 
                 mp4_crf = gr.Slider(label="MP4 Compression", minimum=0, maximum=100, value=16, step=1, info="Lower means better quality. 0 is uncompressed. Change to 16 if you get black outputs. ")
 
+                variant = gr.Dropdown(
+                    label="Flow Matching Variant",
+                    choices=["bh1", "bh2"],
+                    value="bh1",
+                    info="bh2 keeps motion better but may deviate from prompts",
+                )
+
         with gr.Column():
             preview_image = gr.Image(label="Next Latents", height=200, visible=False)
             result_video = gr.Video(label="Finished Frames", autoplay=True, show_share_button=False, height=512, loop=True)
@@ -396,7 +435,22 @@ with block:
 
     gr.HTML('<div style="text-align:center; margin-top:20px;">Share your results and find ideas at the <a href="https://x.com/search?q=framepack&f=live" target="_blank">FramePack Twitter (X) thread</a></div>')
 
-    ips = [input_image, prompt, n_prompt, seed, total_second_length, latent_window_size, steps, cfg, gs, rs, gpu_memory_preservation, use_teacache, mp4_crf]
+    ips = [
+        input_image,
+        prompt,
+        n_prompt,
+        seed,
+        total_second_length,
+        latent_window_size,
+        steps,
+        cfg,
+        gs,
+        rs,
+        gpu_memory_preservation,
+        use_teacache,
+        mp4_crf,
+        variant,
+    ]
     start_button.click(fn=process, inputs=ips, outputs=[result_video, preview_image, progress_desc, progress_bar, start_button, end_button])
     end_button.click(fn=end_process)
 

--- a/demo_gradio_f1.py
+++ b/demo_gradio_f1.py
@@ -100,7 +100,7 @@ os.makedirs(outputs_folder, exist_ok=True)
 
 
 @torch.no_grad()
-def worker(input_image, prompt, n_prompt, seed, total_second_length, latent_window_size, steps, cfg, gs, rs, gpu_memory_preservation, use_teacache, mp4_crf):
+def worker(input_image, prompt, n_prompt, seed, total_second_length, latent_window_size, steps, cfg, gs, rs, gpu_memory_preservation, use_teacache, mp4_crf, variant):
     total_latent_sections = (total_second_length * 30) / (latent_window_size * 4)
     total_latent_sections = int(max(round(total_latent_sections), 1))
 
@@ -254,6 +254,7 @@ def worker(input_image, prompt, n_prompt, seed, total_second_length, latent_wind
                 clean_latent_2x_indices=clean_latent_2x_indices,
                 clean_latents_4x=clean_latents_4x,
                 clean_latent_4x_indices=clean_latent_4x_indices,
+                variant=variant,
                 callback=callback,
             )
 
@@ -297,7 +298,22 @@ def worker(input_image, prompt, n_prompt, seed, total_second_length, latent_wind
     return
 
 
-def process(input_image, prompt, n_prompt, seed, total_second_length, latent_window_size, steps, cfg, gs, rs, gpu_memory_preservation, use_teacache, mp4_crf):
+def process(
+    input_image,
+    prompt,
+    n_prompt,
+    seed,
+    total_second_length,
+    latent_window_size,
+    steps,
+    cfg,
+    gs,
+    rs,
+    gpu_memory_preservation,
+    use_teacache,
+    mp4_crf,
+    variant,
+):
     global stream
     assert input_image is not None, 'No input image!'
 
@@ -305,7 +321,23 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
 
     stream = AsyncStream()
 
-    async_run(worker, input_image, prompt, n_prompt, seed, total_second_length, latent_window_size, steps, cfg, gs, rs, gpu_memory_preservation, use_teacache, mp4_crf)
+    async_run(
+        worker,
+        input_image,
+        prompt,
+        n_prompt,
+        seed,
+        total_second_length,
+        latent_window_size,
+        steps,
+        cfg,
+        gs,
+        rs,
+        gpu_memory_preservation,
+        use_teacache,
+        mp4_crf,
+        variant,
+    )
 
     output_filename = None
 
@@ -369,6 +401,13 @@ with block:
 
                 mp4_crf = gr.Slider(label="MP4 Compression", minimum=0, maximum=100, value=16, step=1, info="Lower means better quality. 0 is uncompressed. Change to 16 if you get black outputs. ")
 
+                variant = gr.Dropdown(
+                    label="Flow Matching Variant",
+                    choices=["bh1", "bh2"],
+                    value="bh1",
+                    info="bh2 keeps motion better but may deviate from prompts",
+                )
+
         with gr.Column():
             preview_image = gr.Image(label="Next Latents", height=200, visible=False)
             result_video = gr.Video(label="Finished Frames", autoplay=True, show_share_button=False, height=512, loop=True)
@@ -377,7 +416,22 @@ with block:
 
     gr.HTML('<div style="text-align:center; margin-top:20px;">Share your results and find ideas at the <a href="https://x.com/search?q=framepack&f=live" target="_blank">FramePack Twitter (X) thread</a></div>')
 
-    ips = [input_image, prompt, n_prompt, seed, total_second_length, latent_window_size, steps, cfg, gs, rs, gpu_memory_preservation, use_teacache, mp4_crf]
+    ips = [
+        input_image,
+        prompt,
+        n_prompt,
+        seed,
+        total_second_length,
+        latent_window_size,
+        steps,
+        cfg,
+        gs,
+        rs,
+        gpu_memory_preservation,
+        use_teacache,
+        mp4_crf,
+        variant,
+    ]
     start_button.click(fn=process, inputs=ips, outputs=[result_video, preview_image, progress_desc, progress_bar, start_button, end_button])
     end_button.click(fn=end_process)
 

--- a/diffusers_helper/pipelines/k_diffusion_hunyuan.py
+++ b/diffusers_helper/pipelines/k_diffusion_hunyuan.py
@@ -28,6 +28,7 @@ def get_flux_sigmas_from_mu(n, mu):
 def sample_hunyuan(
         transformer,
         sampler='unipc',
+        variant='bh1',
         initial_latent=None,
         concat_latent=None,
         strength=1.0,
@@ -113,7 +114,15 @@ def sample_hunyuan(
     )
 
     if sampler == 'unipc':
-        results = sample_unipc(k_model, latents, sigmas, extra_args=sampler_kwargs, disable=False, callback=callback)
+        results = sample_unipc(
+            k_model,
+            latents,
+            sigmas,
+            extra_args=sampler_kwargs,
+            disable=False,
+            callback=callback,
+            variant=variant,
+        )
     else:
         raise NotImplementedError(f'Sampler {sampler} is not supported.')
 


### PR DESCRIPTION
## Summary
- expose `variant` argument in `sample_hunyuan`
- add variant dropdown to the demo gradio scripts
- document UniPC variants in README

## Testing
- `python -m py_compile demo_gradio.py demo_gradio_f1.py diffusers_helper/pipelines/k_diffusion_hunyuan.py`

------
https://chatgpt.com/codex/tasks/task_e_6847873d9d308322807157d00a553201